### PR TITLE
adds the guidelines and personal details page, button design, and con…

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -1,0 +1,91 @@
+# Contributing to ID8
+
+This guide outlines the steps for contributing, including setting up your environment, creating branches, and submitting pull requests.
+
+## Table of Contents
+
+- [Branch Naming Convention](#branch-naming-convention)
+- [How to Contribute](#how-to-contribute)
+  - [Step 1: Create a New Branch](#step-1-create-a-new-branch)
+  - [Step 2: Implement Your Feature or Fix](#step-2-implement-your-feature-or-fix)
+  - [Step 3: Pull Latest Changes from `main`](#step-3-pull-latest-changes-from-main)
+  - [Step 4: Commit and Push](#step-4-commit-and-push)
+  - [Step 5: Submit a Pull Request](#step-5-submit-a-pull-request)
+- [Code Review Process](#code-review-process)
+- [Best Practices](#best-practices)
+
+## Branch Naming Convention
+
+When creating a new branch, please use the following naming convention:
+
+`<your-username>/<feature-or-task>`
+
+**Example:**
+- flavia/login-page
+
+## How to Contribute
+
+### Step 1: Create a New Branch
+
+Before you start working, create a new branch off of the `main` branch using the naming convention mentioned above.
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/your-username/ID8.git
+   cd ID8.git
+   ```
+2. Checkout the main branch and pull the latest changes:
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+3. Create a new branch for your feature or fix:
+   ```bash
+   git checkout -b <your-username>/<feature-or-task>
+   ```
+
+### Step 2: Implement Your Feature or Fix
+
+Now that you’re in your own branch, make the necessary changes or implement your feature. 
+
+### Step 3: Pull Latest Changes from `main`
+
+Before committing and pushing your changes, make sure your branch is up-to-date with the latest changes from `main`:
+
+```bash
+git pull origin main
+```
+
+Resolve any merge conflicts if necessary.
+
+### Step 4: Commit and Push
+
+Once your feature is ready and your branch is up to date, commit your changes with a descriptive message:
+
+```bash
+git add .
+git commit -m "Brief description of your changes"
+```
+
+Then push your branch to your remote repository:
+
+```bash
+git push origin <your-username>/<feature-or-task>
+```
+
+### Step 5: Submit a Pull Request
+
+Once your changes are pushed, open a pull request (PR) from your branch to the main repository's `main` branch.
+
+1. Go to the repository on GitHub.
+2. Click the "Compare & pull request" button.
+3. There should be an automatic template that you have to fill out. 
+
+## Code Review Process
+
+Once you've submitted your pull request, it will be reviewed by one or more maintainers, with the requirement of at least one for merging. You may be asked to make additional changes, so please be prepared to address any feedback. Once approved, you will be able to merge your changes into the `main` branch.
+
+## Best Practices
+
+- **Write Clear Commit Messages**: Each commit should describe the intent of your changes.
+- **Keep Your Branch Up to Date**: Regularly pull from `main` to avoid large merge conflicts later.

--- a/contributions.md
+++ b/contributions.md
@@ -60,13 +60,12 @@ git pull origin main
 
 Resolve any merge conflicts if necessary.
 
-
 ### Step 4: Linting and Formatting
 
-Before committing and pushing your changes, run: 
+Before committing and pushing your changes, run:
 
-- `npm run lint` to fix formatting 
-- `npm run format` to fix formatting issues  
+- `npm run lint` to fix formatting
+- `npm run format` to fix formatting issues
 
 ### Step 5: Commit and Push
 

--- a/contributions.md
+++ b/contributions.md
@@ -9,8 +9,9 @@ This guide outlines the steps for contributing, including setting up your enviro
   - [Step 1: Create a New Branch](#step-1-create-a-new-branch)
   - [Step 2: Implement Your Feature or Fix](#step-2-implement-your-feature-or-fix)
   - [Step 3: Pull Latest Changes from `main`](#step-3-pull-latest-changes-from-main)
-  - [Step 4: Commit and Push](#step-4-commit-and-push)
-  - [Step 5: Submit a Pull Request](#step-5-submit-a-pull-request)
+  - [Step 4: Linting and Formatting](#step-4-linting-and-formatting)
+  - [Step 5: Commit and Push](#step-4-commit-and-push)
+  - [Step 6: Submit a Pull Request](#step-5-submit-a-pull-request)
 - [Code Review Process](#code-review-process)
 - [Best Practices](#best-practices)
 
@@ -21,6 +22,7 @@ When creating a new branch, please use the following naming convention:
 `<your-username>/<feature-or-task>`
 
 **Example:**
+
 - flavia/login-page
 
 ## How to Contribute
@@ -46,7 +48,7 @@ Before you start working, create a new branch off of the `main` branch using the
 
 ### Step 2: Implement Your Feature or Fix
 
-Now that you’re in your own branch, make the necessary changes or implement your feature. 
+Now that you’re in your own branch, make the necessary changes or implement your feature.
 
 ### Step 3: Pull Latest Changes from `main`
 
@@ -58,7 +60,15 @@ git pull origin main
 
 Resolve any merge conflicts if necessary.
 
-### Step 4: Commit and Push
+
+### Step 4: Linting and Formatting
+
+Before committing and pushing your changes, run: 
+
+- `npm run lint` to fix formatting 
+- `npm run format` to fix formatting issues  
+
+### Step 5: Commit and Push
 
 Once your feature is ready and your branch is up to date, commit your changes with a descriptive message:
 
@@ -73,13 +83,13 @@ Then push your branch to your remote repository:
 git push origin <your-username>/<feature-or-task>
 ```
 
-### Step 5: Submit a Pull Request
+### Step 6: Submit a Pull Request
 
 Once your changes are pushed, open a pull request (PR) from your branch to the main repository's `main` branch.
 
 1. Go to the repository on GitHub.
 2. Click the "Compare & pull request" button.
-3. There should be an automatic template that you have to fill out. 
+3. There should be an automatic template that you have to fill out.
 
 ## Code Review Process
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@emotion/react": "^11.13.3",
 				"@emotion/styled": "^11.13.0",
 				"@geist-ui/core": "^2.3.8",
+				"@mui/icons-material": "^6.1.4",
 				"@mui/material": "^6.1.4",
 				"@t3-oss/env-nextjs": "^0.10.1",
 				"geist": "^1.3.0",
@@ -683,6 +684,32 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mui-org"
+			}
+		},
+		"node_modules/@mui/icons-material": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.1.4.tgz",
+			"integrity": "sha512-nhXBNSP3WkY0pz8dg25VIYIXJkhdRLRKZtD50f9OuHVQ1eh8b+enmvaZQF0o5M8cs1sR6wQHwZYwG34qDZeG0g==",
+			"license": "MIT",
+			"dependencies": {
+			  "@babel/runtime": "^7.25.7"
+			},
+			"engines": {
+			  "node": ">=14.0.0"
+			},
+			"funding": {
+			  "type": "opencollective",
+			  "url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+			  "@mui/material": "^6.1.4",
+			  "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+			  "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+			  "@types/react": {
+				"optional": true
+			  }
 			}
 		},
 		"node_modules/@mui/material": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -692,24 +692,24 @@
 			"integrity": "sha512-nhXBNSP3WkY0pz8dg25VIYIXJkhdRLRKZtD50f9OuHVQ1eh8b+enmvaZQF0o5M8cs1sR6wQHwZYwG34qDZeG0g==",
 			"license": "MIT",
 			"dependencies": {
-			  "@babel/runtime": "^7.25.7"
+				"@babel/runtime": "^7.25.7"
 			},
 			"engines": {
-			  "node": ">=14.0.0"
+				"node": ">=14.0.0"
 			},
 			"funding": {
-			  "type": "opencollective",
-			  "url": "https://opencollective.com/mui-org"
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
 			},
 			"peerDependencies": {
-			  "@mui/material": "^6.1.4",
-			  "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-			  "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+				"@mui/material": "^6.1.4",
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
-			  "@types/react": {
-				"optional": true
-			  }
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@emotion/react": "^11.13.3",
 		"@emotion/styled": "^11.13.0",
 		"@geist-ui/core": "^2.3.8",
+		"@mui/icons-material": "^6.1.4",
 		"@mui/material": "^6.1.4",
 		"@t3-oss/env-nextjs": "^0.10.1",
 		"geist": "^1.3.0",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,59 +1,19 @@
-# Contributing to IDE
-
-Here is a simple guide to contributing to ID8. Please read it before making a pull request.
-
-## Getting Started
-
-To contribute to the project, follow these steps:
-
-1. Clone the respository to you local.
-2. VsCode will suggest the a linter and formatter based on the project settings. Please install them.
-3. Create your branch from `main`.
-4. If you've added code that should be tested, add tests.
-5. If you've changed APIs, update the documentation.
-6. Before pushing code ensure the test suite passes.
-7. For linting and formatting we have setup the project to lint and format on every save so ensure you editor has autosave on.
-8. If your code does not pass the tests or lint check(you will see this in the pull request), fix the issues.
-9. To fix formatting run `npm run lint`.
-10. To fix formatting issues run `npm run format`.
-
-## Branches
-
-The naming convention for branch naming looks as follows:
-`yournane/feature-name`</br>
-
-Example: `lewiskyron/back_end_config.`
-
-## Pull Requests
-
-### NOTE: NOTHING SHOULD EVER BE MERGED DIRECTLY TO MAIN EXCEPT IN VERY RARE CASES!
-
-In your pull request, make sure to include a description of what you did. Use the template provided below. For changes please include screenshots as well.
-
-````markdown
-Title: [Brief description of the change]
-
 ## Description
 
-[Provide a detailed description of the changes you have made. Explain what you have changed and why. If the PR addresses a specific issue or feature request from the issue tracker, include a link to that issue.]
+Provide a detailed description of the changes you have made. Explain what you have changed and why. If the PR addresses a specific issue or feature request, include a link to that issue.
 
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Tests
+- [ ] Tests (adding or updating tests)
 - [ ] Documentation update
 
-## How Has This Been Tested/ How others can test?
+## Testing Instructions
 
-[Describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration.]
+Describe the tests that you ran to verify your changes. Provide instructions so that reviewers can reproduce the results. List any relevant details for your test configuration.
 
-## Screenshots (if applicable):
+## Screenshots (if applicable)
 
-[If your changes have visual components, please add screenshots showing the affected pages.]
-
-```
-
-```
-````
+If your changes include visual components, add screenshots showing the affected pages or elements.

--- a/src/app/guidelines/page.tsx
+++ b/src/app/guidelines/page.tsx
@@ -11,6 +11,7 @@ const GuidelinesScreen: React.FC = () => {
 				alignItems: "center",
 				background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)",
 				fontFamily: "Outfit, sans-serif",
+				padding:"70px",
 			}}
 		>
 			<Container

--- a/src/app/guidelines/page.tsx
+++ b/src/app/guidelines/page.tsx
@@ -11,7 +11,7 @@ const GuidelinesScreen: React.FC = () => {
 				alignItems: "center",
 				background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)",
 				fontFamily: "Outfit, sans-serif",
-				padding:"70px",
+				padding: "70px",
 			}}
 		>
 			<Container

--- a/src/app/guidelines/page.tsx
+++ b/src/app/guidelines/page.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Box, Typography, Button, Container } from '@mui/material';
+
+const GuidelinesScreen: React.FC = () => {
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        background: 'linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)', 
+        fontFamily: 'Outfit, sans-serif', 
+      }}
+    >
+      <Container
+        maxWidth={false}
+        sx={{
+          width: "1500px",
+          backgroundColor: '#FFFFFF',
+          padding: '48px',
+          borderRadius: '16px',
+          border: '1px solid #D6D6E7',
+          boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.1)',
+        }}
+      >
+        {/* Heading Section */}
+        <Typography
+          variant="h4"
+          component="h1"
+          sx={{
+            textAlign: 'center',
+            fontWeight: 600, 
+            fontSize: '32px', 
+            lineHeight: '40.32px', 
+            marginBottom: '12px',
+            fontFamily: 'Outfit, sans-serif',
+          }}
+        >
+          Welcome to Startup Validator
+        </Typography>
+
+        <Typography
+          variant="h6"
+          component="h2"
+          sx={{
+            textAlign: 'center',
+            fontWeight: 400, 
+            fontSize: '24px', 
+            lineHeight: '30.24px', 
+            color: '#6C6C80',
+            marginBottom: '32px',
+            fontFamily: 'Outfit, sans-serif',
+          }}
+        >
+          Take a moment to review our guidelines
+        </Typography>
+
+        {/* Guidelines List */}
+        <Box
+          component="ul"
+          sx={{
+            listStyle: 'none',
+            paddingLeft: 0,
+            marginBottom: '32px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center', 
+            gap: 2,
+          }}
+        >
+          {[
+            'Be constructive and specific: Offer actionable feedback with clear examples for improvement.',
+            'Stay respectful: Maintain a positive tone; avoid harsh criticism or dismissive language.',
+            'Focus on the idea, not the person: Critique the concept, not the individual proposing it.',
+            'Be concise: Keep your feedback brief and to the point, avoiding unnecessary details.',
+            'Ask questions: Encourage deeper thinking by asking clarifying or thought-provoking questions.',
+            'Highlight strengths: Acknowledge what works well to balance criticism and motivate improvement.',
+          ].map((text, index) => (
+            <Box
+              key={index}
+              component="li"
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '50px 1fr',
+                alignItems: 'center',
+                marginBottom: '16px',
+                justifyContent: 'center',
+                width: '100%',
+                maxWidth: '700px',
+              }}
+            >
+              <Typography
+                variant="h2"
+                sx={{
+                  color: '#B3B3C6',
+                  fontSize: '2.5rem',
+                  textAlign: 'right',
+                  paddingRight: '16px',
+                  fontFamily: 'Outfit, sans-serif',
+                }}
+              >
+                {index + 1}
+              </Typography>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontWeight: 400,
+                  fontSize: '16px', 
+                  lineHeight: '20.16px', 
+                  color: '#333333',
+                  fontFamily: 'Outfit, sans-serif',
+                }}
+              >
+                {text}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+
+        {/* Next Button */}
+        <Box sx={{ textAlign: 'center' }}>
+            <Button
+                variant="contained"
+                className="custom-next-button"
+            >
+                Next
+            </Button>
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default GuidelinesScreen;

--- a/src/app/guidelines/page.tsx
+++ b/src/app/guidelines/page.tsx
@@ -1,135 +1,132 @@
-import React from 'react';
-import { Box, Typography, Button, Container } from '@mui/material';
+import React from "react";
+import { Box, Typography, Button, Container } from "@mui/material";
 
 const GuidelinesScreen: React.FC = () => {
-  return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        background: 'linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)', 
-        fontFamily: 'Outfit, sans-serif', 
-      }}
-    >
-      <Container
-        maxWidth="md"
-        sx={{
-          width: "1500px",
-          backgroundColor: '#FFFFFF',
-          padding: '48px',
-          borderRadius: '16px',
-          border: '1px solid #D6D6E7',
-          boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.1)',
-        }}
-      >
-        {/* Heading Section */}
-        <Typography
-          variant="h4"
-          component="h1"
-          sx={{
-            textAlign: 'center',
-            fontWeight: 600, 
-            fontSize: '32px', 
-            lineHeight: '40.32px', 
-            marginBottom: '12px',
-            fontFamily: 'Outfit, sans-serif',
-          }}
-        >
-          Welcome to Startup Validator
-        </Typography>
+	return (
+		<Box
+			sx={{
+				minHeight: "100vh",
+				display: "flex",
+				justifyContent: "center",
+				alignItems: "center",
+				background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)",
+				fontFamily: "Outfit, sans-serif",
+			}}
+		>
+			<Container
+				maxWidth="md"
+				sx={{
+					width: "1500px",
+					backgroundColor: "#FFFFFF",
+					padding: "48px",
+					borderRadius: "16px",
+					border: "1px solid #D6D6E7",
+					boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+				}}
+			>
+				{/* Heading Section */}
+				<Typography
+					variant="h4"
+					component="h1"
+					sx={{
+						textAlign: "center",
+						fontWeight: 600,
+						fontSize: "32px",
+						lineHeight: "40.32px",
+						marginBottom: "12px",
+						fontFamily: "Outfit, sans-serif",
+					}}
+				>
+					Welcome to Startup Validator
+				</Typography>
 
-        <Typography
-          variant="h6"
-          component="h2"
-          sx={{
-            textAlign: 'center',
-            fontWeight: 400, 
-            fontSize: '24px', 
-            lineHeight: '30.24px', 
-            color: '#6C6C80',
-            marginBottom: '32px',
-            fontFamily: 'Outfit, sans-serif',
-          }}
-        >
-          Take a moment to review our guidelines
-        </Typography>
+				<Typography
+					variant="h6"
+					component="h2"
+					sx={{
+						textAlign: "center",
+						fontWeight: 400,
+						fontSize: "24px",
+						lineHeight: "30.24px",
+						color: "#6C6C80",
+						marginBottom: "32px",
+						fontFamily: "Outfit, sans-serif",
+					}}
+				>
+					Take a moment to review our guidelines
+				</Typography>
 
-        {/* Guidelines List */}
-        <Box
-          component="ul"
-          sx={{
-            listStyle: 'none',
-            paddingLeft: 0,
-            marginBottom: '32px',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center', 
-            gap: 2,
-          }}
-        >
-          {[
-            'Be constructive and specific: Offer actionable feedback with clear examples for improvement.',
-            'Stay respectful: Maintain a positive tone; avoid harsh criticism or dismissive language.',
-            'Focus on the idea, not the person: Critique the concept, not the individual proposing it.',
-            'Be concise: Keep your feedback brief and to the point, avoiding unnecessary details.',
-            'Ask questions: Encourage deeper thinking by asking clarifying or thought-provoking questions.',
-            'Highlight strengths: Acknowledge what works well to balance criticism and motivate improvement.',
-          ].map((text, index) => (
-            <Box
-              key={index}
-              component="li"
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: '50px 1fr',
-                alignItems: 'center',
-                marginBottom: '16px',
-                justifyContent: 'center',
-                width: '100%',
-                maxWidth: '700px',
-              }}
-            >
-              <Typography
-                variant="h2"
-                sx={{
-                  color: '#B3B3C6',
-                  fontSize: '2.5rem',
-                  textAlign: 'right',
-                  paddingRight: '16px',
-                  fontFamily: 'Outfit, sans-serif',
-                }}
-              >
-                {index + 1}
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{
-                  fontWeight: 400,
-                  fontSize: '16px', 
-                  lineHeight: '20.16px', 
-                  color: '#333333',
-                  fontFamily: 'Outfit, sans-serif',
-                }}
-              >
-                {text}
-              </Typography>
-            </Box>
-          ))}
-        </Box>
+				{/* Guidelines List */}
+				<Box
+					component="ul"
+					sx={{
+						listStyle: "none",
+						paddingLeft: 0,
+						marginBottom: "32px",
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						gap: 2,
+					}}
+				>
+					{[
+						"Be constructive and specific: Offer actionable feedback with clear examples for improvement.",
+						"Stay respectful: Maintain a positive tone; avoid harsh criticism or dismissive language.",
+						"Focus on the idea, not the person: Critique the concept, not the individual proposing it.",
+						"Be concise: Keep your feedback brief and to the point, avoiding unnecessary details.",
+						"Ask questions: Encourage deeper thinking by asking clarifying or thought-provoking questions.",
+						"Highlight strengths: Acknowledge what works well to balance criticism and motivate improvement.",
+					].map((text, index) => (
+						<Box
+							key={index}
+							component="li"
+							sx={{
+								display: "grid",
+								gridTemplateColumns: "50px 1fr",
+								alignItems: "center",
+								marginBottom: "16px",
+								justifyContent: "center",
+								width: "100%",
+								maxWidth: "700px",
+							}}
+						>
+							<Typography
+								variant="h2"
+								sx={{
+									color: "#B3B3C6",
+									fontSize: "2.5rem",
+									textAlign: "right",
+									paddingRight: "16px",
+									fontFamily: "Outfit, sans-serif",
+								}}
+							>
+								{index + 1}
+							</Typography>
+							<Typography
+								variant="body1"
+								sx={{
+									fontWeight: 400,
+									fontSize: "16px",
+									lineHeight: "20.16px",
+									color: "#333333",
+									fontFamily: "Outfit, sans-serif",
+								}}
+							>
+								{text}
+							</Typography>
+						</Box>
+					))}
+				</Box>
 
-        {/* Next Button */}
-        <Box sx={{ textAlign: 'center' }}>
-            <Button
-                variant="contained"
-                className="custom-next-button"
-            >
-                Next
-            </Button>
-        </Box>
-      </Container>
-    </Box>
-  );
+				{/* Next Button */}
+				<Box sx={{ textAlign: "center" }}>
+					<Button variant="contained" className="custom-next-button">
+						Next
+					</Button>
+				</Box>
+			</Container>
+		</Box>
+	);
 };
 
 export default GuidelinesScreen;

--- a/src/app/guidelines/page.tsx
+++ b/src/app/guidelines/page.tsx
@@ -14,7 +14,7 @@ const GuidelinesScreen: React.FC = () => {
       }}
     >
       <Container
-        maxWidth={false}
+        maxWidth="md"
         sx={{
           width: "1500px",
           backgroundColor: '#FFFFFF',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Button from "@mui/material/Button";
 import Header from "./_components/Header";
+import Link from 'next/link'; 
 
 export default function HomePage() {
 	const [counter, setCounter] = useState(0);
@@ -22,6 +23,21 @@ export default function HomePage() {
 			<div className="flex flex-col items-center justify-center rounded-2xl bg-slate-500 px-16 py-8">
 				{counter}
 			</div>
+      {/* New Section for Routing. Only added this to facilitate development while we don't have a main page and we want to see the other pages in a easy way. We will remove it later*/}
+      <div className="flex flex-col items-center justify-center gap-4 mt-4">
+        {/* Link to Guidelines Page */}
+        <Link href="/guidelines" passHref>
+          <Button variant="contained" color="primary">
+            Go to Guidelines
+          </Button>
+        </Link>
+        {/* Link to Personal Details Page */}
+        <Link href="/personal-details" passHref>
+          <Button variant="contained" color="primary">
+            Go to Personal Details
+          </Button>
+        </Link>
+      </div>
 		</main>
 	);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import Button from "@mui/material/Button";
 import Header from "./_components/Header";
-import Link from 'next/link'; 
+import Link from "next/link";
 
 export default function HomePage() {
 	const [counter, setCounter] = useState(0);
@@ -23,21 +23,21 @@ export default function HomePage() {
 			<div className="flex flex-col items-center justify-center rounded-2xl bg-slate-500 px-16 py-8">
 				{counter}
 			</div>
-      {/* New Section for Routing. Only added this to facilitate development while we don't have a main page and we want to see the other pages in a easy way. We will remove it later*/}
-      <div className="flex flex-col items-center justify-center gap-4 mt-4">
-        {/* Link to Guidelines Page */}
-        <Link href="/guidelines" passHref>
-          <Button variant="contained" color="primary">
-            Go to Guidelines
-          </Button>
-        </Link>
-        {/* Link to Personal Details Page */}
-        <Link href="/personal-details" passHref>
-          <Button variant="contained" color="primary">
-            Go to Personal Details
-          </Button>
-        </Link>
-      </div>
+			{/* New Section for Routing. Only added this to facilitate development while we don't have a main page and we want to see the other pages in a easy way. We will remove it later*/}
+			<div className="mt-4 flex flex-col items-center justify-center gap-4">
+				{/* Link to Guidelines Page */}
+				<Link href="/guidelines" passHref>
+					<Button variant="contained" color="primary">
+						Go to Guidelines
+					</Button>
+				</Link>
+				{/* Link to Personal Details Page */}
+				<Link href="/personal-details" passHref>
+					<Button variant="contained" color="primary">
+						Go to Personal Details
+					</Button>
+				</Link>
+			</div>
 		</main>
 	);
 }

--- a/src/app/personal-details/page.tsx
+++ b/src/app/personal-details/page.tsx
@@ -32,6 +32,7 @@ const PersonalDetailsScreen: React.FC = () => {
 				justifyContent: "center",
 				alignItems: "center",
 				background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)",
+				padding:"70px",
 			}}
 		>
 			<Container

--- a/src/app/personal-details/page.tsx
+++ b/src/app/personal-details/page.tsx
@@ -1,253 +1,260 @@
 "use client";
 
 import React, { useState } from "react";
-import { Box, Button, TextField, Container, Typography, IconButton } from "@mui/material";
+import {
+	Box,
+	Button,
+	TextField,
+	Container,
+	Typography,
+	IconButton,
+} from "@mui/material";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 
 const PersonalDetailsScreen: React.FC = () => {
-  const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [jobTitle, setJobTitle] = useState("");
-  const [bio, setBio] = useState("");
-  const [linkedin, setLinkedin] = useState("");
-  const [aboutMe, setAboutMe] = useState("");
+	const [name, setName] = useState("");
+	const [username, setUsername] = useState("");
+	const [email, setEmail] = useState("");
+	const [jobTitle, setJobTitle] = useState("");
+	const [bio, setBio] = useState("");
+	const [linkedin, setLinkedin] = useState("");
+	const [aboutMe, setAboutMe] = useState("");
 
-  const handleNext = () => {
-    // Form submission logic here
-  };
+	const handleNext = () => {
+		// Form submission logic here
+	};
 
-  return (
-    <Box
-      sx={{
-        minHeight: "100vh",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)", 
-      }}
-    >
-      <Container
-        maxWidth="md"
-        sx={{
-          backgroundColor: "#FFFFFF",
-          padding: "48px", 
-          borderRadius: "16px",
-          border: "1px solid #D6D6E7",
-          boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
-        }}
-      >
-        {/* Header */}
-        <Typography
-          variant="h5"
-          component="h1"
-          sx={{
-            textAlign: "center",
-            color: "#000000",
-            fontWeight: 600,
-            fontSize: "32px",
-            lineHeight: "40.32px",
-            marginBottom: "24px", 
-            fontFamily: "'Outfit', sans-serif",
-          }}
-        >
-          Tell Us About Yourself
-        </Typography>
-        <Typography
-          variant="body2"
-          sx={{
-            textAlign: "center",
-            color: "#000000",
-            marginBottom: "32px", 
-            fontSize: "24px",
-            lineHeight: "30.24px",
-            fontFamily: "'Outfit', sans-serif",
-            fontWeight: 200,
-          }}
-        >
-          This helps other founders understand who you are when reviewing your ideas.
-        </Typography>
+	return (
+		<Box
+			sx={{
+				minHeight: "100vh",
+				display: "flex",
+				justifyContent: "center",
+				alignItems: "center",
+				background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)",
+			}}
+		>
+			<Container
+				maxWidth="md"
+				sx={{
+					backgroundColor: "#FFFFFF",
+					padding: "48px",
+					borderRadius: "16px",
+					border: "1px solid #D6D6E7",
+					boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+				}}
+			>
+				{/* Header */}
+				<Typography
+					variant="h5"
+					component="h1"
+					sx={{
+						textAlign: "center",
+						color: "#000000",
+						fontWeight: 600,
+						fontSize: "32px",
+						lineHeight: "40.32px",
+						marginBottom: "24px",
+						fontFamily: "'Outfit', sans-serif",
+					}}
+				>
+					Tell Us About Yourself
+				</Typography>
+				<Typography
+					variant="body2"
+					sx={{
+						textAlign: "center",
+						color: "#000000",
+						marginBottom: "32px",
+						fontSize: "24px",
+						lineHeight: "30.24px",
+						fontFamily: "'Outfit', sans-serif",
+						fontWeight: 200,
+					}}
+				>
+					This helps other founders understand who you are when reviewing your
+					ideas.
+				</Typography>
 
-        {/* Avatar Upload */}
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            gap: "32px", 
-            marginBottom: "32px", 
-          }}
-        >
-          <IconButton
-            sx={{
-              width: "64px",
-              height: "64px",
-              borderRadius: "50%",
-              backgroundColor: "#F0F0F5",
-              border: "2px dashed #D6D6E7",
-              "&:hover": {
-                backgroundColor: "#E8E8F0",
-              },
-            }}
-          >
-            <AddPhotoAlternateIcon sx={{ fontSize: "32px", color: "#6C6C80" }} />
-          </IconButton>
-          <Button
-            variant="outlined"
-            sx={{
-              textTransform: "none",
-              padding: "12px 36px", 
-              fontSize: "16px",
-              borderColor: "#D6D6E7",
-              color: "#6C6C80",
-              "&:hover": {
-                borderColor: "#C0C0D8",
-              },
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              lineHeight: "20.16px",
-            }}
-          >
-            Upload Photo or Avatar
-          </Button>
-        </Box>
+				{/* Avatar Upload */}
+				<Box
+					sx={{
+						display: "flex",
+						justifyContent: "center",
+						alignItems: "center",
+						gap: "32px",
+						marginBottom: "32px",
+					}}
+				>
+					<IconButton
+						sx={{
+							width: "64px",
+							height: "64px",
+							borderRadius: "50%",
+							backgroundColor: "#F0F0F5",
+							border: "2px dashed #D6D6E7",
+							"&:hover": {
+								backgroundColor: "#E8E8F0",
+							},
+						}}
+					>
+						<AddPhotoAlternateIcon
+							sx={{ fontSize: "32px", color: "#6C6C80" }}
+						/>
+					</IconButton>
+					<Button
+						variant="outlined"
+						sx={{
+							textTransform: "none",
+							padding: "12px 36px",
+							fontSize: "16px",
+							borderColor: "#D6D6E7",
+							color: "#6C6C80",
+							"&:hover": {
+								borderColor: "#C0C0D8",
+							},
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							lineHeight: "20.16px",
+						}}
+					>
+						Upload Photo or Avatar
+					</Button>
+				</Box>
 
-        {/* Form Fields */}
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "24px", 
-            marginBottom: "32px",
-          }}
-        >
-          {/* Name Field */}
-          <TextField
-            fullWidth
-            label="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            variant="outlined"
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
+				{/* Form Fields */}
+				<Box
+					sx={{
+						display: "flex",
+						flexDirection: "column",
+						gap: "24px",
+						marginBottom: "32px",
+					}}
+				>
+					{/* Name Field */}
+					<TextField
+						fullWidth
+						label="Name"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						variant="outlined"
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
 
-          {/* Username Field */}
-          <TextField
-            fullWidth
-            label="Username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            variant="outlined"
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
+					{/* Username Field */}
+					<TextField
+						fullWidth
+						label="Username"
+						value={username}
+						onChange={(e) => setUsername(e.target.value)}
+						variant="outlined"
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
 
-          {/* Email Field */}
-          <TextField
-            fullWidth
-            label="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            variant="outlined"
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
+					{/* Email Field */}
+					<TextField
+						fullWidth
+						label="Email"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
+						variant="outlined"
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
 
-          {/* Job Title Field */}
-          <TextField
-            fullWidth
-            label="Job Title"
-            value={jobTitle}
-            onChange={(e) => setJobTitle(e.target.value)}
-            variant="outlined"
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
+					{/* Job Title Field */}
+					<TextField
+						fullWidth
+						label="Job Title"
+						value={jobTitle}
+						onChange={(e) => setJobTitle(e.target.value)}
+						variant="outlined"
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
 
-          {/* Bio Field */}
-          <TextField
-            fullWidth
-            label="Bio"
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-            variant="outlined"
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
+					{/* Bio Field */}
+					<TextField
+						fullWidth
+						label="Bio"
+						value={bio}
+						onChange={(e) => setBio(e.target.value)}
+						variant="outlined"
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
 
-          {/* LinkedIn Field */}
-          <TextField
-            fullWidth
-            label="LinkedIn URL"
-            value={linkedin}
-            onChange={(e) => setLinkedin(e.target.value)}
-            variant="outlined"
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
+					{/* LinkedIn Field */}
+					<TextField
+						fullWidth
+						label="LinkedIn URL"
+						value={linkedin}
+						onChange={(e) => setLinkedin(e.target.value)}
+						variant="outlined"
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
 
-          {/* About Me Field */}
-          <TextField
-            fullWidth
-            label="About me"
-            value={aboutMe}
-            onChange={(e) => setAboutMe(e.target.value)}
-            variant="outlined"
-            multiline
-            rows={3} 
-            inputProps={{ maxLength: 600 }}
-            sx={{
-              fontFamily: "'Outfit', sans-serif",
-              fontWeight: 400,
-              fontSize: "24px",
-              lineHeight: "30.24px",
-            }}
-          />
-        </Box>
+					{/* About Me Field */}
+					<TextField
+						fullWidth
+						label="About me"
+						value={aboutMe}
+						onChange={(e) => setAboutMe(e.target.value)}
+						variant="outlined"
+						multiline
+						rows={3}
+						inputProps={{ maxLength: 600 }}
+						sx={{
+							fontFamily: "'Outfit', sans-serif",
+							fontWeight: 400,
+							fontSize: "24px",
+							lineHeight: "30.24px",
+						}}
+					/>
+				</Box>
 
-        {/* Next Button */}
-        <Box sx={{ textAlign: 'center' }}>
-          <Button
-            variant="contained"
-            className="custom-next-button"
-          >
-            Next
-          </Button>
-        </Box>
-      </Container>
-    </Box>
-  );
+				{/* Next Button */}
+				<Box sx={{ textAlign: "center" }}>
+					<Button variant="contained" className="custom-next-button">
+						Next
+					</Button>
+				</Box>
+			</Container>
+		</Box>
+	);
 };
 
 export default PersonalDetailsScreen;

--- a/src/app/personal-details/page.tsx
+++ b/src/app/personal-details/page.tsx
@@ -32,7 +32,7 @@ const PersonalDetailsScreen: React.FC = () => {
 				justifyContent: "center",
 				alignItems: "center",
 				background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)",
-				padding:"70px",
+				padding: "70px",
 			}}
 		>
 			<Container

--- a/src/app/personal-details/page.tsx
+++ b/src/app/personal-details/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import React, { useState } from "react";
+import { Box, Button, TextField, Container, Typography, IconButton } from "@mui/material";
+import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
+
+const PersonalDetailsScreen: React.FC = () => {
+  const [name, setName] = useState("");
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [jobTitle, setJobTitle] = useState("");
+  const [bio, setBio] = useState("");
+  const [linkedin, setLinkedin] = useState("");
+  const [aboutMe, setAboutMe] = useState("");
+
+  const handleNext = () => {
+    // Form submission logic here
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        background: "linear-gradient(135deg, #F7F7F8, #E3E7FF, #DCE0FF)", 
+      }}
+    >
+      <Container
+        maxWidth="md"
+        sx={{
+          backgroundColor: "#FFFFFF",
+          padding: "48px", 
+          borderRadius: "16px",
+          border: "1px solid #D6D6E7",
+          boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+        }}
+      >
+        {/* Header */}
+        <Typography
+          variant="h5"
+          component="h1"
+          sx={{
+            textAlign: "center",
+            color: "#000000",
+            fontWeight: 600,
+            fontSize: "32px",
+            lineHeight: "40.32px",
+            marginBottom: "24px", 
+            fontFamily: "'Outfit', sans-serif",
+          }}
+        >
+          Tell Us About Yourself
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{
+            textAlign: "center",
+            color: "#000000",
+            marginBottom: "32px", 
+            fontSize: "24px",
+            lineHeight: "30.24px",
+            fontFamily: "'Outfit', sans-serif",
+            fontWeight: 200,
+          }}
+        >
+          This helps other founders understand who you are when reviewing your ideas.
+        </Typography>
+
+        {/* Avatar Upload */}
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            gap: "32px", 
+            marginBottom: "32px", 
+          }}
+        >
+          <IconButton
+            sx={{
+              width: "64px",
+              height: "64px",
+              borderRadius: "50%",
+              backgroundColor: "#F0F0F5",
+              border: "2px dashed #D6D6E7",
+              "&:hover": {
+                backgroundColor: "#E8E8F0",
+              },
+            }}
+          >
+            <AddPhotoAlternateIcon sx={{ fontSize: "32px", color: "#6C6C80" }} />
+          </IconButton>
+          <Button
+            variant="outlined"
+            sx={{
+              textTransform: "none",
+              padding: "12px 36px", 
+              fontSize: "16px",
+              borderColor: "#D6D6E7",
+              color: "#6C6C80",
+              "&:hover": {
+                borderColor: "#C0C0D8",
+              },
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              lineHeight: "20.16px",
+            }}
+          >
+            Upload Photo or Avatar
+          </Button>
+        </Box>
+
+        {/* Form Fields */}
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "24px", 
+            marginBottom: "32px",
+          }}
+        >
+          {/* Name Field */}
+          <TextField
+            fullWidth
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            variant="outlined"
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+
+          {/* Username Field */}
+          <TextField
+            fullWidth
+            label="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            variant="outlined"
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+
+          {/* Email Field */}
+          <TextField
+            fullWidth
+            label="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            variant="outlined"
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+
+          {/* Job Title Field */}
+          <TextField
+            fullWidth
+            label="Job Title"
+            value={jobTitle}
+            onChange={(e) => setJobTitle(e.target.value)}
+            variant="outlined"
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+
+          {/* Bio Field */}
+          <TextField
+            fullWidth
+            label="Bio"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            variant="outlined"
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+
+          {/* LinkedIn Field */}
+          <TextField
+            fullWidth
+            label="LinkedIn URL"
+            value={linkedin}
+            onChange={(e) => setLinkedin(e.target.value)}
+            variant="outlined"
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+
+          {/* About Me Field */}
+          <TextField
+            fullWidth
+            label="About me"
+            value={aboutMe}
+            onChange={(e) => setAboutMe(e.target.value)}
+            variant="outlined"
+            multiline
+            rows={3} 
+            inputProps={{ maxLength: 600 }}
+            sx={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 400,
+              fontSize: "24px",
+              lineHeight: "30.24px",
+            }}
+          />
+        </Box>
+
+        {/* Next Button */}
+        <Box sx={{ textAlign: 'center' }}>
+          <Button
+            variant="contained"
+            className="custom-next-button"
+          >
+            Next
+          </Button>
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default PersonalDetailsScreen;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,20 +1,20 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap");
 
 .custom-next-button {
-    background: linear-gradient(90deg, #4E1EC1, #A958F1);
-    color: #FFFFFF;
-    font-weight: bold;
-    font-size: 16px;
-    border-radius: 10px;
-    width: 300px;
-    height: 48px;
-    padding: 14px 117px;
-    font-family: 'Outfit', sans-serif;
-  }
+	background: linear-gradient(90deg, #4e1ec1, #a958f1);
+	color: #ffffff;
+	font-weight: bold;
+	font-size: 16px;
+	border-radius: 10px;
+	width: 300px;
+	height: 48px;
+	padding: 14px 117px;
+	font-family: "Outfit", sans-serif;
+}
 
 .custom-next-button:hover {
-    background: linear-gradient(90deg, #3E0FB8, #9450E0);
-  }
+	background: linear-gradient(90deg, #3e0fb8, #9450e0);
+}
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,21 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;600&display=swap');
+
+.custom-next-button {
+    background: linear-gradient(90deg, #4E1EC1, #A958F1);
+    color: #FFFFFF;
+    font-weight: bold;
+    font-size: 16px;
+    border-radius: 10px;
+    width: 300px;
+    height: 48px;
+    padding: 14px 117px;
+    font-family: 'Outfit', sans-serif;
+  }
+
+.custom-next-button:hover {
+    background: linear-gradient(90deg, #3E0FB8, #9450E0);
+  }
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
 	theme: {
 		extend: {
 			fontFamily: {
+        outfit: ['Outfit', 'sans-serif'],
 				sans: ["var(--font-geist-sans)", ...fontFamily.sans],
 			},
 		},

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,7 @@ export default {
 	theme: {
 		extend: {
 			fontFamily: {
-        outfit: ['Outfit', 'sans-serif'],
+				outfit: ["Outfit", "sans-serif"],
 				sans: ["var(--font-geist-sans)", ...fontFamily.sans],
 			},
 		},


### PR DESCRIPTION
## Description

In this PR: 

- I have added the guidelines and personal details page.
- I have added the button styling to globals.css
- I have added the contributions.md file.
- I have updated the pull_request_template file. 
- I have created a simple routing from the main page to the pages I have added to facilitate the navigation of the devs to the pages I created. This will be eliminated and was also added so that every time somebody wanted to see the pages, they would not have to update the URL and simply click a button from the main page. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests
- [x] Documentation update

## How Has this been tested/ How can others test it?

#### For the Guidelines and Personal Details Page
Simply run `npm run dev`  in the terminal and click the buttons that show on the main page to the guidelines and personal details page. 
<img width="301" alt="Screenshot 2024-10-20 at 2 03 50 PM" src="https://github.com/user-attachments/assets/67e22eb0-2ee9-44dd-818a-6d6e79749aab">

#### For the pull_request_template.md 
When opening a new PR, you should automatically see the content of pull_request_template.md added to the text box. 

#### For contributions.md 
If the reproduction of the steps leads you to easily contribute to the project. 


## Screenshots (if applicable):

### Guidelines Page
<img width="1710" alt="Screenshot 2024-10-20 at 4 34 07 PM" src="https://github.com/user-attachments/assets/208b2898-325e-410c-8171-907dd4faf7eb">

### Personal Details Page 
<img width="1710" alt="Screenshot 2024-10-20 at 4 34 58 PM" src="https://github.com/user-attachments/assets/ccdd6e37-e8dd-4dbf-ba5a-514e221b0c55">
Screen at 80% so it fits within 1 screenshot

```

```
````
