### PR TITLE
Add GitHub Action to randomly assign a PR reviewer

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -16,7 +16,12 @@ jobs:
         id: select-reviewer
 
       - name: Assign the Reviewer
-        uses: kentaro-m/auto-assign-action@v1
+        uses: actions/github-script@v6
         with:
-          reviewers: ${{ steps.select-reviewer.outputs.reviewer }}
-          assign: reviewers
+          script: |
+            github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: ["${{ steps.select-reviewer.outputs.reviewer }}"]
+            })

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,22 @@
+name: Assign Random Reviewer
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Choose Random Reviewer
+        run: |
+          REVIEWERS=("ucey-star" "avalucianelson" "FlaIespa" "katyaivaniuk" "lewiskyron" "matviikotolyk" "Mykhailo-Chudyk" "nnnour")
+          SELECTED_REVIEWER=${REVIEWERS[$RANDOM % ${#REVIEWERS[@]}]}
+          echo "reviewer=$SELECTED_REVIEWER" >> $GITHUB_ENV
+        id: select-reviewer
+
+      - name: Assign the Reviewer
+        uses: kentaro-m/auto-assign-action@v1
+        with:
+          reviewers: ${{ steps.select-reviewer.outputs.reviewer }}
+          assign: reviewers

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ yarn-error.log*
 
 # idea files
 .idea
+
+#history
+.history/


### PR DESCRIPTION
## Description

This PR introduces a GitHub Action to randomly assign a reviewer when a pull request (PR) is created. The action leverages a custom script to select a random reviewer from a predefined list of GitHub usernames and automatically assigns that user to the PR.

The reason for implementing this feature is to ensure an even distribution of PR review responsibilities within the team, encouraging collaboration and preventing bottlenecks where the same reviewer is overloaded. Additionally, the use of this automation reduces the need for manual intervention in the PR review assignment process.

Changes include:

- A GitHub Action file (assign-reviewer.yml) located in .github/workflows/, which triggers when a new pull request is opened.
- A script to randomly select a reviewer from an array of team members.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions

To test this:
- After you make a PR, check if it got randomly assigned to a member of the team

## Screenshots (if applicable)

If your changes include visual components, add screenshots showing the affected pages or elements.
