### PR TITLE
Fix incorrect import path for GradientButton in Project Idea page

### DIFF
--- a/src/app/project_idea/page.tsx
+++ b/src/app/project_idea/page.tsx
@@ -15,7 +15,7 @@ import {
 	ListItemText,
 	SelectChangeEvent,
 } from "@mui/material";
-import GradientButton from "../_components/GradientButton";
+import GradientButton from "../../components/GradientButton";
 
 const ProjectIdeaScreen: React.FC = () => {
 	const [projectName, setProjectName] = useState("");


### PR DESCRIPTION
## Description

This PR fixes an issue with the Project Idea page that was not loading correctly due to an incorrect import path for the GradientButton component. The original import was pointing a path which does not exist. I corrected the path allowing the page to render correctly.

The incorrect path ../_components/GradientButton assumed that _components was located at the parent level of project_idea/, which does not exist.

The correct path ../../components/GradientButton navigates two levels up from project_idea/ to reach src/components/, where GradientButton.tsx is located. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions

Run the app locally using npm run dev.
Navigate to the Project Idea page.
Verify that the page now loads without any errors.

## Screenshots (if applicable)
Just uploaded a picture of how the page was not loading initially
<img width="563" alt="Screenshot 2024-11-15 at 2 53 20 PM" src="https://github.com/user-attachments/assets/283eba71-7ffa-4d35-8aa6-e1a398c84a4c">
