### PR TITLE
Remove duplicate name from project card + fix "go back" arrow on the popup

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React from "react";
 import { Box, Button, Typography, Chip } from "@mui/material";
 
@@ -78,14 +79,14 @@ const Card: React.FC<CardProps> = ({
 						gap: "4px", // Small gap between name and date
 					}}
 				>
-					<Typography
+					{/* <Typography
 						variant="body1"
 						sx={{
 							color: "var(--color-text-secondary)",
 						}}
 					>
 						{name}
-					</Typography>
+					</Typography> */}
 					<Typography
 						variant="body1"
 						sx={{

--- a/src/components/ExploreMore.tsx
+++ b/src/components/ExploreMore.tsx
@@ -50,6 +50,7 @@ const ExploreMore: React.FC<ExploreMoreProps> = ({ data, onBack }) => {
 					sx={{
 						position: "absolute",
 						left: 0,
+						top: 0,
 						cursor: "pointer",
 						color: "#5370F7",
 					}}
@@ -60,6 +61,7 @@ const ExploreMore: React.FC<ExploreMoreProps> = ({ data, onBack }) => {
 						fontSize: "32px",
 						fontWeight: 600,
 						lineHeight: "40.32px",
+						marginTop: "32px",
 						textAlign: "left",
 						textUnderlinePosition: "from-font",
 						textDecorationSkipInk: "none",

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -99,7 +99,7 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 					const mappedOtherProjects = (otherProjectsResponse.data ?? []).map(
 						(project) => ({
 							id: project.project_id, // Keep UUID as string
-							name: project.project_name ?? "Unknown",
+							name: project.project_name ?? "Unknown", // TODO: at the moment the same as the headline, redundant
 							date: new Date(project.created_at).toLocaleDateString(),
 							headline: project.project_name ?? "No Headline",
 							descriptionShort: project.tagline ?? "",
@@ -126,7 +126,7 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 		};
 
 		void fetchProjects();
-	}, [user?.id]);
+	}, [user]);
 
 	if (loading) {
 		return <Typography>Loading...</Typography>;


### PR DESCRIPTION
## Description

Remove the redundant second name component from the project card + fix the margin so that the "Back" arrow is visible in the project popup

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions

Checkout the `matvikotolyk/project-cards-polish` branch

## Screenshots (if applicable)

If your changes include visual components, add screenshots showing the affected pages or elements.
<img width="929" alt="Screenshot 2024-12-02 at 21 26 50" src="https://github.com/user-attachments/assets/30d9dce2-40d5-4563-8208-1c2fba9d4162">
