### PR TITLE
Add tooltips and example entries to Edit Project and My Profile pages

### DIFF
--- a/src/app/project_idea/page.tsx
+++ b/src/app/project_idea/page.tsx
@@ -62,7 +62,7 @@ export default async function ProjectIdeaScreen({
 				>
 					Fill out as much detail as possible to help others understand your
 					project. You can view the example entry{" "}
-					<a href="https://id8.guru/home?id=4f2828f6-43f8-40dd-b19e-85901af4a926" target="_blank" style={{ color: "#9450e0" }}>here</a>, along with the type of feedback you can expect.
+					<a href="https://id8.guru/home?id=50e834ba-12d5-466e-8734-42a54487f5a7" target="_blank" style={{ color: "#9450e0" }}>here</a>, along with the type of feedback you can expect.
 				</Typography>
 
 				<ProjectIdeaForm user={user} redirectTo={redirectTo} />

--- a/src/app/project_idea/page.tsx
+++ b/src/app/project_idea/page.tsx
@@ -62,7 +62,14 @@ export default async function ProjectIdeaScreen({
 				>
 					Fill out as much detail as possible to help others understand your
 					project. You can view the example entry{" "}
-					<a href="https://id8.guru/home?id=50e834ba-12d5-466e-8734-42a54487f5a7" target="_blank" style={{ color: "#9450e0" }}>here</a>, along with the type of feedback you can expect.
+					<a
+						href="https://id8.guru/home?id=50e834ba-12d5-466e-8734-42a54487f5a7"
+						target="_blank"
+						style={{ color: "#9450e0" }}
+					>
+						here
+					</a>
+					, along with the type of feedback you can expect.
 				</Typography>
 
 				<ProjectIdeaForm user={user} redirectTo={redirectTo} />

--- a/src/app/project_idea/page.tsx
+++ b/src/app/project_idea/page.tsx
@@ -61,7 +61,8 @@ export default async function ProjectIdeaScreen({
 					}}
 				>
 					Fill out as much detail as possible to help others understand your
-					project.
+					project. You can view the example entry{" "}
+					<a href="https://id8.guru/home?id=4f2828f6-43f8-40dd-b19e-85901af4a926" target="_blank" style={{ color: "#9450e0" }}>here</a>, along with the type of feedback you can expect.
 				</Typography>
 
 				<ProjectIdeaForm user={user} redirectTo={redirectTo} />

--- a/src/components/ExploreMore.tsx
+++ b/src/components/ExploreMore.tsx
@@ -80,23 +80,12 @@ const ExploreMore: React.FC<ExploreMoreProps> = ({ data, onBack }) => {
 					gap: "var(--spacing-medium)",
 				}}
 			>
-				<TitleResponse
-					title="Quick Pitch*"
-					response={data.descriptionShort}
-				/>
+				<TitleResponse title="Quick Pitch*" response={data.descriptionShort} />
 				{data.productLink && (
-					<TitleResponse
-						title="Project URL"
-						response={data.productLink}
-						link
-					/>
+					<TitleResponse title="Project URL" response={data.productLink} link />
 				)}
 				{data.demoLink && (
-					<TitleResponse
-						title="Demo Link"
-						response={data.demoLink}
-						link
-					/>
+					<TitleResponse title="Demo Link" response={data.demoLink} link />
 				)}
 				{data.descriptionLong && (
 					<TitleResponse

--- a/src/components/ExploreMore.tsx
+++ b/src/components/ExploreMore.tsx
@@ -81,32 +81,32 @@ const ExploreMore: React.FC<ExploreMoreProps> = ({ data, onBack }) => {
 				}}
 			>
 				<TitleResponse
-					title="Describe what your company does in 50 characters or less.*"
+					title="Quick Pitch*"
 					response={data.descriptionShort}
 				/>
 				{data.productLink && (
 					<TitleResponse
-						title="Please provide a link to the product, if any."
+						title="Project URL"
 						response={data.productLink}
 						link
 					/>
 				)}
 				{data.demoLink && (
 					<TitleResponse
-						title="If you have a demo, attach it below."
+						title="Demo Link"
 						response={data.demoLink}
 						link
 					/>
 				)}
 				{data.descriptionLong && (
 					<TitleResponse
-						title="What is your company going to make? Please describe your product and what it does or will do."
+						title="Detailed Description"
 						response={data.descriptionLong}
 					/>
 				)}
-				{data.descriptionLong && (
+				{data.feedbackQuestion && (
 					<TitleResponse
-						title="What aspect of the project idea needs feedback?"
+						title="Feedback Request"
 						response={data.feedbackQuestion}
 					/>
 				)}

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -57,14 +57,14 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 	};
 
 	useEffect(() => {
-		const queryId = searchParams.get('id');
+		const queryId = searchParams.get("id");
 		if (queryId && (myProjects.length > 0 || otherProjects.length > 0)) {
 			const allProjects = [...myProjects, ...otherProjects];
-			const cardToExplore = allProjects.find(card => card.id === queryId);
+			const cardToExplore = allProjects.find((card) => card.id === queryId);
 			if (cardToExplore) {
 				handleExploreMore(cardToExplore);
 				const newUrl = window.location.pathname;
-				window.history.replaceState({}, '', newUrl);
+				window.history.replaceState({}, "", newUrl);
 			}
 		}
 	}, [searchParams, myProjects, otherProjects]);

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -7,6 +7,7 @@ import ExploreMore from "../components/ExploreMore";
 import Feedback from "../components/Feedback";
 import { type User } from "@supabase/supabase-js";
 import supabaseClient from "~/api/supabaseConfig";
+import { useSearchParams, useRouter } from "next/navigation";
 
 interface HomeContentProps {
 	user: User | null;
@@ -41,6 +42,8 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 	const [myProjects, setMyProjects] = useState<CardData[]>([]);
 	const [otherProjects, setOtherProjects] = useState<CardData[]>([]);
 	const [loading, setLoading] = useState(true);
+	const searchParams = useSearchParams();
+	const router = useRouter();
 
 	const handleExploreMore = (card: CardData) => {
 		console.log("Selected card ID:", card.id);
@@ -52,6 +55,19 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 		setView("cards");
 		setSelectedCard(null);
 	};
+
+	useEffect(() => {
+		const queryId = searchParams.get('id');
+		if (queryId && (myProjects.length > 0 || otherProjects.length > 0)) {
+			const allProjects = [...myProjects, ...otherProjects];
+			const cardToExplore = allProjects.find(card => card.id === queryId);
+			if (cardToExplore) {
+				handleExploreMore(cardToExplore);
+				const newUrl = window.location.pathname;
+				window.history.replaceState({}, '', newUrl);
+			}
+		}
+	}, [searchParams, myProjects, otherProjects]);
 
 	useEffect(() => {
 		const fetchProjects = async () => {

--- a/src/components/PersonalDetailsForm.tsx
+++ b/src/components/PersonalDetailsForm.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Box, TextField, Snackbar, Alert, Typography, Tooltip } from "@mui/material";
+import {
+	Box,
+	TextField,
+	Snackbar,
+	Alert,
+	Typography,
+	Tooltip,
+} from "@mui/material";
 import GradientButton from "../components/GradientButton";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
@@ -10,7 +17,7 @@ import { type User } from "@supabase/supabase-js";
 import supabaseClient from "~/api/supabaseConfig";
 import type { Database } from "~/types/database.types";
 import { useRouter } from "next/navigation";
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 interface PersonalDetailsFormProps {
 	user: User | null;
@@ -192,8 +199,13 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 							>
 								Username*
 							</Typography>
-							<Tooltip title="Choose a unique username that will identify you in the community" placement="right">
-								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							<Tooltip
+								title="Choose a unique username that will identify you in the community"
+								placement="right"
+							>
+								<InfoOutlinedIcon
+									sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+								/>
 							</Tooltip>
 						</Box>
 						<TextField
@@ -220,8 +232,13 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 							>
 								Birth Date
 							</Typography>
-							<Tooltip title="Your date of birth helps us personalize your experience" placement="right">
-								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							<Tooltip
+								title="Your date of birth helps us personalize your experience"
+								placement="right"
+							>
+								<InfoOutlinedIcon
+									sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+								/>
 							</Tooltip>
 						</Box>
 						<LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -250,7 +267,9 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 								Gender
 							</Typography>
 							<Tooltip title="How do you identify?" placement="right">
-								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+								<InfoOutlinedIcon
+									sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+								/>
 							</Tooltip>
 						</Box>
 						<TextField
@@ -277,8 +296,13 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 							>
 								Bio
 							</Typography>
-							<Tooltip title="Tell us about yourself, your interests, and what you're passionate about" placement="right">
-								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							<Tooltip
+								title="Tell us about yourself, your interests, and what you're passionate about"
+								placement="right"
+							>
+								<InfoOutlinedIcon
+									sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+								/>
 							</Tooltip>
 						</Box>
 						<TextField
@@ -307,8 +331,13 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 							>
 								Workplace
 							</Typography>
-							<Tooltip title="Where do you currently work? This helps build your professional profile" placement="right">
-								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							<Tooltip
+								title="Where do you currently work? This helps build your professional profile"
+								placement="right"
+							>
+								<InfoOutlinedIcon
+									sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+								/>
 							</Tooltip>
 						</Box>
 						<TextField
@@ -335,8 +364,13 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 							>
 								LinkedIn Profile
 							</Typography>
-							<Tooltip title="Share your LinkedIn profile to connect with other professionals" placement="right">
-								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							<Tooltip
+								title="Share your LinkedIn profile to connect with other professionals"
+								placement="right"
+							>
+								<InfoOutlinedIcon
+									sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+								/>
 							</Tooltip>
 						</Box>
 						<TextField
@@ -349,9 +383,7 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 						/>
 					</Box>
 
-					<Box
-						sx={{ display: "flex", justifyContent: "center" }}
-					>
+					<Box sx={{ display: "flex", justifyContent: "center" }}>
 						<GradientButton
 							type="submit"
 							content="Save Profile"

--- a/src/components/PersonalDetailsForm.tsx
+++ b/src/components/PersonalDetailsForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Box, TextField, Snackbar, Alert } from "@mui/material";
+import { Box, TextField, Snackbar, Alert, Typography, Tooltip } from "@mui/material";
 import GradientButton from "../components/GradientButton";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
@@ -10,6 +10,7 @@ import { type User } from "@supabase/supabase-js";
 import supabaseClient from "~/api/supabaseConfig";
 import type { Database } from "~/types/database.types";
 import { useRouter } from "next/navigation";
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 interface PersonalDetailsFormProps {
 	user: User | null;
@@ -177,78 +178,203 @@ const PersonalDetailsForm: React.FC<PersonalDetailsFormProps> = ({
 						padding: "8px",
 					}}
 				>
-					<TextField
-						fullWidth
-						label="Username"
-						value={username}
-						onChange={(e) => setUsername(e.target.value)}
-						variant="outlined"
-					/>
-					<LocalizationProvider dateAdapter={AdapterDateFns}>
-						<DatePicker
-							label="Date of Birth"
-							value={dateOfBirth}
-							onChange={(newValue) => {
-								setDateOfBirth(newValue);
-							}}
+					<Box sx={{ textAlign: "left" }}>
+						<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+							<Typography
+								variant="subtitle1"
+								sx={{
+									fontWeight: 500,
+									marginBottom: "8px",
+									marginTop: "8px",
+									color: "#2D2D2D",
+									fontFamily: "'Outfit', sans-serif",
+								}}
+							>
+								Username*
+							</Typography>
+							<Tooltip title="Choose a unique username that will identify you in the community" placement="right">
+								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							</Tooltip>
+						</Box>
+						<TextField
+							fullWidth
+							placeholder="e.g., john.doe"
+							value={username}
+							onChange={(e) => setUsername(e.target.value)}
+							variant="outlined"
+							required
 						/>
-					</LocalizationProvider>
-					<TextField
-						fullWidth
-						label="Gender"
-						value={gender}
-						onChange={(e) => setGender(e.target.value)}
-						variant="outlined"
-					/>
-					{/* disabled for now */}
-					{/* <TextField
-						fullWidth
-						label="Address"
-						value={address}
-						onChange={(e) => setAddress(e.target.value)}
-						variant="outlined"
-					/> */}
-					<TextField
-						fullWidth
-						label="What best describes you?"
-						value={description}
-						onChange={(e) => setDescription(e.target.value)}
-						variant="outlined"
-					/>
-					<TextField
-						fullWidth
-						label="Where do you work?"
-						value={workplace}
-						onChange={(e) => setWorkplace(e.target.value)}
-						variant="outlined"
-					/>
-					<TextField
-						fullWidth
-						label="LinkedIn URL"
-						value={linkedin}
-						onChange={(e) => setLinkedin(e.target.value)}
-						variant="outlined"
-					/>
-				</Box>
-				<Box sx={{ display: "flex", justifyContent: "center" }}>
-					<GradientButton type="submit" className="w-1/2" content="Save" />
-				</Box>
-			</form>
+					</Box>
 
-			{/* Snackbar for notifications */}
-			<Snackbar
-				open={snackbar.open}
-				autoHideDuration={snackbar.severity === "error" ? 10000 : 1000}
-				onClose={handleCloseSnackbar}
-			>
-				<Alert
+					<Box sx={{ textAlign: "left" }}>
+						<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+							<Typography
+								variant="subtitle1"
+								sx={{
+									fontWeight: 500,
+									marginBottom: "8px",
+									marginTop: "8px",
+									color: "#2D2D2D",
+									fontFamily: "'Outfit', sans-serif",
+								}}
+							>
+								Birth Date
+							</Typography>
+							<Tooltip title="Your date of birth helps us personalize your experience" placement="right">
+								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							</Tooltip>
+						</Box>
+						<LocalizationProvider dateAdapter={AdapterDateFns}>
+							<DatePicker
+								value={dateOfBirth}
+								onChange={(newValue) => {
+									setDateOfBirth(newValue);
+								}}
+								sx={{ width: "100%" }}
+							/>
+						</LocalizationProvider>
+					</Box>
+
+					<Box sx={{ textAlign: "left" }}>
+						<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+							<Typography
+								variant="subtitle1"
+								sx={{
+									fontWeight: 500,
+									marginBottom: "8px",
+									marginTop: "8px",
+									color: "#2D2D2D",
+									fontFamily: "'Outfit', sans-serif",
+								}}
+							>
+								Gender
+							</Typography>
+							<Tooltip title="How do you identify?" placement="right">
+								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							</Tooltip>
+						</Box>
+						<TextField
+							fullWidth
+							placeholder="e.g., Female, Male, Non-binary, Prefer not to say"
+							value={gender}
+							onChange={(e) => setGender(e.target.value)}
+							variant="outlined"
+							required
+						/>
+					</Box>
+
+					<Box sx={{ textAlign: "left" }}>
+						<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+							<Typography
+								variant="subtitle1"
+								sx={{
+									fontWeight: 500,
+									marginBottom: "8px",
+									marginTop: "8px",
+									color: "#2D2D2D",
+									fontFamily: "'Outfit', sans-serif",
+								}}
+							>
+								Bio
+							</Typography>
+							<Tooltip title="Tell us about yourself, your interests, and what you're passionate about" placement="right">
+								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							</Tooltip>
+						</Box>
+						<TextField
+							fullWidth
+							multiline
+							rows={3}
+							placeholder="e.g., I'm a software engineer passionate about creating innovative solutions..."
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							variant="outlined"
+							required
+						/>
+					</Box>
+
+					<Box sx={{ textAlign: "left" }}>
+						<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+							<Typography
+								variant="subtitle1"
+								sx={{
+									fontWeight: 500,
+									marginBottom: "8px",
+									marginTop: "8px",
+									color: "#2D2D2D",
+									fontFamily: "'Outfit', sans-serif",
+								}}
+							>
+								Workplace
+							</Typography>
+							<Tooltip title="Where do you currently work? This helps build your professional profile" placement="right">
+								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							</Tooltip>
+						</Box>
+						<TextField
+							fullWidth
+							placeholder="e.g., Google, Self-employed, Student at Stanford"
+							value={workplace}
+							onChange={(e) => setWorkplace(e.target.value)}
+							variant="outlined"
+							required
+						/>
+					</Box>
+
+					<Box sx={{ textAlign: "left" }}>
+						<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+							<Typography
+								variant="subtitle1"
+								sx={{
+									fontWeight: 500,
+									marginBottom: "8px",
+									marginTop: "8px",
+									color: "#2D2D2D",
+									fontFamily: "'Outfit', sans-serif",
+								}}
+							>
+								LinkedIn Profile
+							</Typography>
+							<Tooltip title="Share your LinkedIn profile to connect with other professionals" placement="right">
+								<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+							</Tooltip>
+						</Box>
+						<TextField
+							fullWidth
+							placeholder="e.g., https://www.linkedin.com/in/yourprofile"
+							value={linkedin}
+							onChange={(e) => setLinkedin(e.target.value)}
+							variant="outlined"
+							required
+						/>
+					</Box>
+
+					<Box
+						sx={{ display: "flex", justifyContent: "center" }}
+					>
+						<GradientButton
+							type="submit"
+							content="Save Profile"
+							className="w-1/2"
+						/>
+					</Box>
+				</Box>
+
+				{/* Snackbar for notifications */}
+				<Snackbar
+					open={snackbar.open}
+					autoHideDuration={snackbar.severity === "error" ? 10000 : 1000}
 					onClose={handleCloseSnackbar}
-					severity={snackbar.severity}
-					sx={{ width: "100%" }}
 				>
-					{snackbar.message}
-				</Alert>
-			</Snackbar>
+					<Alert
+						onClose={handleCloseSnackbar}
+						severity={snackbar.severity}
+						sx={{ width: "100%" }}
+					>
+						{snackbar.message}
+					</Alert>
+				</Snackbar>
+			</form>
 		</>
 	);
 };

--- a/src/components/ProjectIdeaForm.tsx
+++ b/src/components/ProjectIdeaForm.tsx
@@ -20,7 +20,7 @@ import type { User } from "@supabase/supabase-js";
 import type { Database } from "~/types/database.types";
 import supabaseClient from "~/api/supabaseConfig";
 import { useRouter } from "next/navigation";
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 interface ProjectIdeaFormProps {
 	user: User | null;
@@ -195,8 +195,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Project Name*
 					</Typography>
-					<Tooltip title="What's the name you want people to remember your project by? Keep it short and memorable." placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="What's the name you want people to remember your project by? Keep it short and memorable."
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<TextField
@@ -222,8 +227,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Quick Pitch*
 					</Typography>
-					<Tooltip title="How would you describe your project to someone in an elevator? Focus on the main problem it solves. The limit is 150 characters." placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="How would you describe your project to someone in an elevator? Focus on the main problem it solves. The limit is 150 characters."
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<TextField
@@ -238,7 +248,14 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					variant="outlined"
 					inputProps={{ maxLength: 150 }}
 				/>
-				<span style={{ alignSelf: "flex-end", color: "#6C6C80", fontSize: "14px", marginTop: "4px" }}>
+				<span
+					style={{
+						alignSelf: "flex-end",
+						color: "#6C6C80",
+						fontSize: "14px",
+						marginTop: "4px",
+					}}
+				>
 					Character Counter: {characterCounter}
 				</span>
 			</Box>
@@ -257,8 +274,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Project URL
 					</Typography>
-					<Tooltip title="Where can people find your project online? Include your website, GitHub repository, or any other relevant links." placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="Where can people find your project online? Include your website, GitHub repository, or any other relevant links."
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<TextField
@@ -284,8 +306,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Demo Link
 					</Typography>
-					<Tooltip title="Share a video or interactive demo that shows your project in action. Loom videos work great!" placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="Share a video or interactive demo that shows your project in action. Loom videos work great!"
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<TextField
@@ -311,8 +338,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Detailed Description
 					</Typography>
-					<Tooltip title="What problem does your project solve? Who is it for? How does it work? Include your motivation and technical approach." placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="What problem does your project solve? Who is it for? How does it work? Include your motivation and technical approach."
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<TextField
@@ -340,8 +372,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Feedback Request
 					</Typography>
-					<Tooltip title="What specific aspects of your project would you like feedback on? Technical implementation? User experience? Business model?" placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="What specific aspects of your project would you like feedback on? Technical implementation? User experience? Business model?"
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<TextField
@@ -367,8 +404,13 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					>
 						Project Categories*
 					</Typography>
-					<Tooltip title="Select all academic disciplines that your project relates to. This helps match you with relevant feedback." placement="right">
-						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					<Tooltip
+						title="Select all academic disciplines that your project relates to. This helps match you with relevant feedback."
+						placement="right"
+					>
+						<InfoOutlinedIcon
+							sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }}
+						/>
 					</Tooltip>
 				</Box>
 				<FormControl fullWidth>
@@ -396,9 +438,7 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 				</FormControl>
 			</Box>
 
-			<Box
-				sx={{ display: "flex", justifyContent: "center" }}
-			>
+			<Box sx={{ display: "flex", justifyContent: "center" }}>
 				<GradientButton
 					onClick={handleSaveProject}
 					content="Edit Project"

--- a/src/components/ProjectIdeaForm.tsx
+++ b/src/components/ProjectIdeaForm.tsx
@@ -7,11 +7,12 @@ import {
 	Select,
 	MenuItem,
 	FormControl,
-	InputLabel,
 	Checkbox,
 	ListItemText,
 	Snackbar,
 	Alert,
+	Typography,
+	Tooltip,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material/Select";
 import GradientButton from "../components/GradientButton";
@@ -19,6 +20,7 @@ import type { User } from "@supabase/supabase-js";
 import type { Database } from "~/types/database.types";
 import supabaseClient from "~/api/supabaseConfig";
 import { useRouter } from "next/navigation";
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 interface ProjectIdeaFormProps {
 	user: User | null;
@@ -179,25 +181,55 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 				padding: "8px",
 			}}
 		>
-			<TextField
-				fullWidth
-				label="Project name*"
-				value={projectName}
-				onChange={(e) => setProjectName(e.target.value)}
-				variant="outlined"
-			/>
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Project Name*
+					</Typography>
+					<Tooltip title="What's the name you want people to remember your project by? Keep it short and memorable." placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
+				<TextField
+					fullWidth
+					placeholder="e.g., Seat Magician"
+					value={projectName}
+					onChange={(e) => setProjectName(e.target.value)}
+					variant="outlined"
+				/>
+			</Box>
 
-			<Box
-				sx={{
-					display: "flex",
-					flexDirection: "column",
-					gap: "2px",
-				}}
-			>
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Quick Pitch*
+					</Typography>
+					<Tooltip title="How would you describe your project to someone in an elevator? Focus on the main problem it solves. The limit is 150 characters." placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
 				<TextField
 					fullWidth
 					multiline
-					label="Describe what your project does in 150 characters or less.*"
+					placeholder="e.g., A web app that helps couples create perfect seating charts for their wedding reception"
 					value={tagline}
 					onChange={(e) => {
 						setTagline(e.target.value);
@@ -206,75 +238,170 @@ const ProjectIdeaForm: React.FC<ProjectIdeaFormProps> = ({
 					variant="outlined"
 					inputProps={{ maxLength: 150 }}
 				/>
-				<span style={{ alignSelf: "flex-end", color: "#666" }}>
+				<span style={{ alignSelf: "flex-end", color: "#6C6C80", fontSize: "14px", marginTop: "4px" }}>
 					Character Counter: {characterCounter}
 				</span>
 			</Box>
-			<TextField
-				fullWidth
-				label="Please provide a link to the project, if any."
-				value={projectLink}
-				onChange={(e) => setProjectLink(e.target.value)}
-				variant="outlined"
-			/>
-			<TextField
-				fullWidth
-				label="If you have a demo, link it below."
-				value={demoLink}
-				onChange={(e) => setDemoLink(e.target.value)}
-				variant="outlined"
-			/>
-			<TextField
-				fullWidth
-				label="What is your project going to do? Please describe your product and what it does or will do."
-				value={projectDescription}
-				onChange={(e) => setProjectDescription(e.target.value)}
-				variant="outlined"
-				multiline
-				rows={3}
-			/>
 
-			<TextField
-				fullWidth
-				label="Feedback Question: What aspect of the project idea needs feedback?"
-				value={feedbackQuestion}
-				onChange={(e) => setFeedbackQuestion(e.target.value)}
-				variant="outlined"
-			/>
-
-			<FormControl fullWidth>
-				<InputLabel>
-					What are some tags you would associate with your project idea?*
-				</InputLabel>
-				<Select
-					multiple
-					value={selectedTags}
-					onChange={handleTagChange}
-					label="What are some tags you would associate with your project idea?*"
-					renderValue={(selected) => selected.join(", ")}
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Project URL
+					</Typography>
+					<Tooltip title="Where can people find your project online? Include your website, GitHub repository, or any other relevant links." placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
+				<TextField
+					fullWidth
+					placeholder="e.g., https://www.seatmagician.com"
+					value={projectLink}
+					onChange={(e) => setProjectLink(e.target.value)}
 					variant="outlined"
-				>
-					{[
-						"Computer Science (CS)",
-						"Social Sciences (SS)",
-						"Arts and Humanities (AH)",
-						"Natural Sciences (NS)",
-						"Business (B)",
-					].map((tag) => (
-						<MenuItem key={tag} value={tag}>
-							<Checkbox checked={selectedTags.includes(tag)} />
-							<ListItemText primary={tag} />
-						</MenuItem>
-					))}
-				</Select>
-			</FormControl>
+				/>
+			</Box>
+
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Demo Link
+					</Typography>
+					<Tooltip title="Share a video or interactive demo that shows your project in action. Loom videos work great!" placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
+				<TextField
+					fullWidth
+					placeholder="e.g., https://www.loom.com/share/your-demo"
+					value={demoLink}
+					onChange={(e) => setDemoLink(e.target.value)}
+					variant="outlined"
+				/>
+			</Box>
+
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Detailed Description
+					</Typography>
+					<Tooltip title="What problem does your project solve? Who is it for? How does it work? Include your motivation and technical approach." placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
+				<TextField
+					fullWidth
+					placeholder="e.g., Seat Magician simplifies wedding planning by automating seating arrangements. It considers relationships, preferences, and table constraints to create optimal seating charts..."
+					value={projectDescription}
+					onChange={(e) => setProjectDescription(e.target.value)}
+					variant="outlined"
+					multiline
+					rows={3}
+				/>
+			</Box>
+
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Feedback Request
+					</Typography>
+					<Tooltip title="What specific aspects of your project would you like feedback on? Technical implementation? User experience? Business model?" placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
+				<TextField
+					fullWidth
+					placeholder="e.g., I'm looking for ideas on how to incorporate statistical analysis..."
+					value={feedbackQuestion}
+					onChange={(e) => setFeedbackQuestion(e.target.value)}
+					variant="outlined"
+				/>
+			</Box>
+
+			<Box sx={{ textAlign: "left" }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+					<Typography
+						variant="subtitle1"
+						sx={{
+							fontWeight: 500,
+							marginBottom: "8px",
+							marginTop: "8px",
+							color: "#2D2D2D",
+							fontFamily: "'Outfit', sans-serif",
+						}}
+					>
+						Project Categories*
+					</Typography>
+					<Tooltip title="Select all academic disciplines that your project relates to. This helps match you with relevant feedback." placement="right">
+						<InfoOutlinedIcon sx={{ fontSize: 16, color: "#6C6C80", cursor: "help" }} />
+					</Tooltip>
+				</Box>
+				<FormControl fullWidth>
+					<Select
+						multiple
+						value={selectedTags}
+						onChange={handleTagChange}
+						placeholder="Select tags"
+						renderValue={(selected) => selected.join(", ")}
+						variant="outlined"
+					>
+						{[
+							"Computer Science (CS)",
+							"Social Sciences (SS)",
+							"Arts and Humanities (AH)",
+							"Natural Sciences (NS)",
+							"Business (B)",
+						].map((tag) => (
+							<MenuItem key={tag} value={tag}>
+								<Checkbox checked={selectedTags.includes(tag)} />
+								<ListItemText primary={tag} />
+							</MenuItem>
+						))}
+					</Select>
+				</FormControl>
+			</Box>
 
 			<Box
-				sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+				sx={{ display: "flex", justifyContent: "center" }}
 			>
 				<GradientButton
 					onClick={handleSaveProject}
-					content="Save"
+					content="Edit Project"
 					className="w-1/2"
 				/>
 			</Box>


### PR DESCRIPTION
## Description

1. Implemented tooltips on the Edit Project and My Profile pages.
2. Added a link to an example project on the Edit Project page and updated the /home page to extract the optional id parameter for automatically opening the project. (Note: This is used only when redirecting from the Edit Project page.)
3. Revised titles, placeholders, and added descriptive tooltips to provide clearer guidance on the information users need to enter.
4. When exploring other projects, the entries are not in the "asking form" "Provide a link to the project", but rather statement form like "Project URL" 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions

1. Check if you have the same visual representation of the tooltips and example placeholders. 
2. Confirm that clicking on the "here" link on the Edit Project page redirects you to the correct page, displaying the exemplar project titled "SeatMagician" created by Ava, along with the feedback.

Please note that while clicking "here" on the Edit Project page correctly redirects to the appropriate project ID in production, you will need to change the domain to localhost:3000/home?id=... for local testing, as the production version of the home page does not yet support the logic for automatically opening the project.

## Screenshots (if applicable)
![telegram-cloud-photo-size-2-5393567738330491221-y](https://github.com/user-attachments/assets/0f05ae7c-fd06-4d16-a375-0dff7a183080)

![telegram-cloud-photo-size-2-5393567738330491222-y](https://github.com/user-attachments/assets/5949041e-2de6-46f9-8b8e-89a8861ee6fa)

![telegram-cloud-photo-size-2-5393567738330491223-y](https://github.com/user-attachments/assets/4508d7ac-c062-4c89-808b-56c29664e7c2)


![telegram-cloud-photo-size-2-5393567738330491225-y](https://github.com/user-attachments/assets/7e441abe-8f97-4700-bf87-bdd0bcb7fa27)


If your changes include visual components, add screenshots showing the affected pages or elements.
