### PR TITLE
Finishing Touches: updating branding (fonts, button gradients) to align with Brand Kit/Figma designs

### DIFF
--- a/src/components/AddProjectCard.tsx
+++ b/src/components/AddProjectCard.tsx
@@ -24,7 +24,7 @@ const AddProjectCard: React.FC = () => {
 				alignItems: "center",
 				margin: "0 auto",
 				textAlign: "center",
-				fontFamily: "var(--font-family-outfit)",
+				fontFamily: "Outfit, sans-serif",
 				color: "#4F46E5",
 				fontWeight: "600",
 				fontSize: "1.25rem",

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -54,7 +54,7 @@ const Card: React.FC<CardProps> = ({
 				justifyContent: "flex-start",
 				alignItems: "stretch",
 				gap: "var(--spacing-medium)",
-				fontFamily: "var(--font-family-outfit)",
+				fontFamily: "Outfit, sans-serif",
 				minHeight: "200px",
 				flexGrow: 1,
 				margin: "0 auto",
@@ -79,6 +79,7 @@ const Card: React.FC<CardProps> = ({
 					sx={{
 						fontWeight: "var(--font-weight-bold)",
 						color: "var(--color-text-primary)",
+						fontFamily: "Outfit, sans-serif",
 					}}
 				>
 					{headline}
@@ -98,6 +99,7 @@ const Card: React.FC<CardProps> = ({
 						sx={{
 							fontWeight: "var(--font-weight-bold)",
 							color: "var(--color-text-primary)",
+							fontFamily: "Outfit, sans-serif",
 						}}
 					>
 						{date}
@@ -121,6 +123,7 @@ const Card: React.FC<CardProps> = ({
 						color: "var(--color-text-secondary)",
 						fontStyle: "italic",
 						fontWeight: "var(--font-weight-medium)",
+						fontFamily: "Outfit, sans-serif",
 					}}
 				>
 					{descriptionShort}
@@ -150,6 +153,7 @@ const Card: React.FC<CardProps> = ({
 							height: "22px", // Reduced height for smaller tags
 							padding: "2px 6px", // Smaller padding inside the chip
 							fontWeight: "500", // Maintain readability
+							fontFamily: "Outfit, sans-serif",
 						}}
 					/>
 				))}
@@ -170,7 +174,7 @@ const Card: React.FC<CardProps> = ({
 						minWidth: "150px",
 						padding: "var(--spacing-small) var(--spacing-medium)",
 						whiteSpace: "nowrap",
-						fontFamily: "var(--font-family-outfit)",
+						fontFamily: "Outfit, sans-serif",
 						alignItems: "center",
 					}}
 					onClick={onExploreMore}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React from "react";
-import { Box, Button, Typography, Chip, IconButton } from "@mui/material";
+import { Box, Typography, Chip, IconButton } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import GradientButton from "../components/GradientButton";
 import useMobile from "~/utils/useMobile";
 
 interface CardProps {
@@ -167,20 +168,11 @@ const Card: React.FC<CardProps> = ({
 					justifyContent: "center", // Center the button
 				}}
 			>
-				<Button
-					variant="contained"
-					className="custom-next-button"
-					sx={{
-						minWidth: "150px",
-						padding: "var(--spacing-small) var(--spacing-medium)",
-						whiteSpace: "nowrap",
-						fontFamily: "Outfit, sans-serif",
-						alignItems: "center",
-					}}
+				<GradientButton
 					onClick={onExploreMore}
-				>
-					{buttonLabel} {/* Dynamic button text */}
-				</Button>
+					content={buttonLabel}
+					className="w-full" // Adjust width as needed
+				/>
 
 				{/* Delete Button*/}
 				{isDeletable && (

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -20,7 +20,7 @@ const Comments = ({ comments }: { comments: number }) => {
 				sx={{
 					fontSize: "14px",
 					color: "var(--color-text-primary)",
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 				}}
 			>
 				{comments}

--- a/src/components/ExploreMore.tsx
+++ b/src/components/ExploreMore.tsx
@@ -33,7 +33,7 @@ const ExploreMore: React.FC<ExploreMoreProps> = ({ data, onBack }) => {
 				flexDirection: "column",
 				gap: "var(--spacing-medium)",
 				alignItems: "center",
-				fontFamily: "var(--font-family-outfit)",
+				fontFamily: "Outfit, sans-serif",
 				marginBottom: "12px",
 			}}
 		>
@@ -58,7 +58,7 @@ const ExploreMore: React.FC<ExploreMoreProps> = ({ data, onBack }) => {
 				/>
 				<Typography
 					sx={{
-						fontFamily: "var(--font-family-outfit)",
+						fontFamily: "Outfit, sans-serif",
 						fontSize: "32px",
 						fontWeight: 600,
 						lineHeight: "40.32px",

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -150,12 +150,12 @@ const Feedback: React.FC<FeedbackProps> = ({ projectId, userId }) => {
 				flexDirection: "column",
 				gap: "var(--spacing-medium)",
 				alignItems: "center",
-				fontFamily: "var(--font-family-outfit)",
+				fontFamily: "Outfit, sans-serif",
 			}}
 		>
 			<Typography
 				sx={{
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 					fontSize: "28px",
 					fontWeight: 600,
 					lineHeight: "36px",
@@ -206,7 +206,7 @@ const Feedback: React.FC<FeedbackProps> = ({ projectId, userId }) => {
 				value={comment}
 				onChange={(e) => setComment(e.target.value)}
 				sx={{
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 					fontSize: "16px",
 					marginBottom: "var(--spacing-small)",
 				}}
@@ -222,7 +222,7 @@ const Feedback: React.FC<FeedbackProps> = ({ projectId, userId }) => {
 					padding: "var(--spacing-small) var(--spacing-medium)",
 					whiteSpace: "nowrap",
 					flexShrink: 0,
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 					fontSize: "14px",
 					color: "#FFFFFF",
 				}}

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Box, Button, Typography, TextField } from "@mui/material";
+import { Box, Typography, TextField } from "@mui/material";
 import FeedbackItem from "./FeedbackItem";
 import supabaseClient from "~/api/supabaseConfig";
+import GradientButton from "../components/GradientButton";
 
 interface FeedbackData {
 	id: string;
@@ -212,23 +213,11 @@ const Feedback: React.FC<FeedbackProps> = ({ projectId, userId }) => {
 				}}
 			/>
 
-			<Button
-				variant="contained"
-				className="custom-next-button"
+			<GradientButton
 				onClick={handleAddComment}
-				sx={{
-					width: "fit-content",
-					minWidth: "120px",
-					padding: "var(--spacing-small) var(--spacing-medium)",
-					whiteSpace: "nowrap",
-					flexShrink: 0,
-					fontFamily: "Outfit, sans-serif",
-					fontSize: "14px",
-					color: "#FFFFFF",
-				}}
-			>
-				Send
-			</Button>
+				content="SEND"
+				className="w-full"
+			/>
 		</Box>
 	);
 };

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -145,7 +145,11 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 	}, [user]);
 
 	if (loading) {
-		return <Typography>Loading...</Typography>;
+		return (
+			<Typography sx={{ fontFamily: "Outfit, sans-serif" }}>
+				Loading...
+			</Typography>
+		);
 	}
 
 	return (
@@ -158,7 +162,7 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 				alignItems: "center",
 				background:
 					"linear-gradient(135deg, var(--color-background-primary), #E3E7FF, #DCE0FF)",
-				fontFamily: "var(--font-family-outfit)",
+				fontFamily: "Outfit, sans-serif",
 				padding: isMobile ? "var(--spacing-small)" : "var(--spacing-large)",
 				paddingTop: "90px",
 			}}
@@ -186,6 +190,7 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 							sx={{
 								marginBottom: "16px",
 								fontSize: isMobile ? "1.5rem" : "2rem",
+								fontFamily: "Outfit, sans-serif",
 							}}
 						>
 							My Project
@@ -203,7 +208,9 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 								/>
 							))
 						) : (
-							<Typography>No projects found.</Typography>
+							<Typography sx={{ fontFamily: "Outfit, sans-serif" }}>
+								No projects found.
+							</Typography>
 						)}
 					</Container>
 
@@ -227,6 +234,7 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 							sx={{
 								marginBottom: "16px",
 								fontSize: isMobile ? "1.5rem" : "2rem",
+								fontFamily: "Outfit, sans-serif",
 							}}
 						>
 							Other Projects
@@ -244,7 +252,9 @@ const HomeContent: React.FC<HomeContentProps> = ({ user }) => {
 								/>
 							))
 						) : (
-							<Typography>No other projects found.</Typography>
+							<Typography sx={{ fontFamily: "Outfit, sans-serif" }}>
+								No other projects found.
+							</Typography>
 						)}
 					</Container>
 				</>

--- a/src/components/Likes.tsx
+++ b/src/components/Likes.tsx
@@ -20,7 +20,7 @@ const Likes = ({ likes }: { likes: number }) => {
 				sx={{
 					fontSize: "14px",
 					color: "var(--color-text-primary)",
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 				}}
 			>
 				{likes}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -106,7 +106,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
 										minWidth: "150px",
 										padding: "var(--spacing-small) var(--spacing-medium)",
 										whiteSpace: "nowrap",
-										fontFamily: "var(--font-family-outfit)",
+										fontFamily: "Outfit, sans-serif",
 										alignItems: "center",
 									}}
 								>
@@ -147,7 +147,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
 										minWidth: "150px",
 										padding: "var(--spacing-small) var(--spacing-medium)",
 										whiteSpace: "nowrap",
-										fontFamily: "var(--font-family-outfit)",
+										fontFamily: "Outfit, sans-serif",
 										alignItems: "center",
 									}}
 								>
@@ -186,7 +186,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
 									minWidth: "150px",
 									padding: "var(--spacing-small) var(--spacing-medium)",
 									whiteSpace: "nowrap",
-									fontFamily: "var(--font-family-outfit)",
+									fontFamily: "Outfit, sans-serif",
 									alignItems: "center",
 								}}
 							>
@@ -224,7 +224,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
 									minWidth: "150px",
 									padding: "var(--spacing-small) var(--spacing-medium)",
 									whiteSpace: "nowrap",
-									fontFamily: "var(--font-family-outfit)",
+									fontFamily: "Outfit, sans-serif",
 									alignItems: "center",
 								}}
 							>

--- a/src/components/TitleResponse.tsx
+++ b/src/components/TitleResponse.tsx
@@ -20,7 +20,7 @@ const TitleResponse: React.FC<TitleResponseProps> = ({
 					color: "#000000",
 					fontWeight: 400,
 					fontSize: "20px",
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 					marginBottom: "4px",
 				}}
 			>
@@ -38,7 +38,7 @@ const TitleResponse: React.FC<TitleResponseProps> = ({
 						textDecoration: "underline",
 						fontSize: "20px",
 						fontWeight: 400,
-						fontFamily: "var(--font-family-outfit)",
+						fontFamily: "Outfit, sans-serif",
 					}}
 				>
 					{response}
@@ -49,7 +49,7 @@ const TitleResponse: React.FC<TitleResponseProps> = ({
 						color: "#807F7F",
 						fontSize: "20px",
 						fontWeight: 400,
-						fontFamily: "var(--font-family-outfit)",
+						fontFamily: "Outfit, sans-serif",
 					}}
 				>
 					{response}

--- a/src/components/Views.tsx
+++ b/src/components/Views.tsx
@@ -20,7 +20,7 @@ const Views = ({ views }: { views: number }) => {
 				sx={{
 					fontSize: "14px",
 					color: "var(--color-text-primary)",
-					fontFamily: "var(--font-family-outfit)",
+					fontFamily: "Outfit, sans-serif",
 				}}
 			>
 				{views}


### PR DESCRIPTION
## Description

I've done a comprehensive audit of our site to ensure everything is up to our brand standards according to the brand kit in Notion & the Figma designs. Really, we just had a couple instances where we used the MUI "Button" instead of our "Gradient Button" component, and where we were not using the Outfit font properly. Now, everything should look a bit more similar to the Figma and "feel" more like ID8 :) The updated fonts and consistent buttons should help everything feel more modern, clean, and on-brand. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions

Visit Home, Explore More/Feedback, and Onboarding to see these changes. Alternatively, see the screenshots below: 

## Screenshots (if applicable)

### BEFORE 
<img width="596" alt="Screenshot 2024-12-19 at 10 31 23 PM" src="https://github.com/user-attachments/assets/bc15b194-0c63-469c-b2ff-14c56b0477be" />

### AFTER

<img width="602" alt="Screenshot 2024-12-19 at 11 12 54 PM" src="https://github.com/user-attachments/assets/1375a499-9daa-4a0c-a09a-310b754ca572" />

<img width="602" alt="Screenshot 2024-12-19 at 11 11 43 PM" src="https://github.com/user-attachments/assets/097c9acf-484e-4431-840a-3d1da8c32c17" />

